### PR TITLE
Add release-plz ci workflow

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ CARGO_REGISTRY_TOKEN }}
 
-  sync_docs_to_gh_pages:
+  sync-cargo-docs:
     name: Sync cargo docs to gh-pages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -1,42 +1,42 @@
-name: publish to crates.io
+name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  publish_to_crate_io:
-
+  release-plz:
+    name: Release-plz
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          override: true
-    - name: Publish to crates.io
-      run: |
-        cargo doc
-        cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        cargo publish
-  
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ CARGO_REGISTRY_TOKEN }}
+
   sync_docs_to_gh_pages:
+    name: Sync cargo docs to gh-pages
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-          python-version: '3.10'
+        python-version: '3.10'
     - uses: actions-rs/toolchain@v1
       with:
-          toolchain: stable
-          override: true
+        toolchain: stable
+        override: true
     - name: Sync Docs
       run: |
         cargo doc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,17 @@
 # How to Contribute
 
-- Create an issue or pick an already existing issue. Please avoid creating duplicate issues
-- Fork the repo, add your changes and make a pull request
-- Request for review from either me or other contributors
+-   Create an issue or pick an already existing issue. Please avoid creating duplicate issues
+-   Fork the repo, add your changes and make a pull request
+-   Request for review from either me or other contributors
+
+# How should I write my commits?
+
+This repository follows conventional commits to enable automated releases and changelog generation.
+
+The most important prefixes you should have in mind are:
+
+`fix:`: represents bug fixes, and results in a SemVer patch bump.
+`feat:`: represents a new feature, and results in a SemVer minor bump.
+`<prefix>!`: (e.g. `feat!`:): represents a breaking change (indicated by the !) and results in a SemVer major bump.
+
+Commits that don't follow the Conventional Commit format result in a SemVer patch bump

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpesa"
-version = "1.2.0"
+version = "1.1.0"
 authors = ["Collins Muriuki <murerwacollins@gmail.com>"]
 edition = "2021"
 description = "A wrapper around the M-PESA API in Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpesa"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Collins Muriuki <murerwacollins@gmail.com>"]
 edition = "2021"
 description = "A wrapper around the M-PESA API in Rust."

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An unofficial Rust wrapper around the [Safaricom API](https://developer.safarico
 
 ```toml
 [dependencies]
-mpesa = { version = "1.2.0" }
+mpesa = { version = "1" }
 ```
 
 Optionally, you can disable default-features, which is basically the entire suite of MPESA APIs to conditionally select individual features. (See [Services](#services) table for the full list of Cargo features)
@@ -23,7 +23,7 @@ Example:
 
 ```toml
 [dependencies]
-mpesa = { version = "1.2.0", default_features = false, features = ["b2b", "express_request"] }
+mpesa = { version = "1", default_features = false, features = ["b2b", "express_request"] }
 ```
 
 In your lib or binary crate:
@@ -154,29 +154,29 @@ async fn main() {
 
 The table below shows all the MPESA APIs from Safaricom and those supported by the crate along with their cargo features and usage examples
 
-| API | Cargo Feature | Status | Example |
-| --------------- | --------------- | --------------- | --------------- |
-| [Account Balance](https://developer.safaricom.co.ke/APIs/AccountBalance) | `account_balance` | Stable ✅ | [account balance example](/docs/client/account_balance.md) |
-| [B2B Express Checkout](https://developer.safaricom.co.ke/APIs/B2BExpressCheckout) | N/A | Unimplemented | N/A |
-| [Bill Manager](https://developer.safaricom.co.ke/APIs/BillManager) | `bill_manager` | Unstable ⚠️ | [bill manager examples](/docs/client/bill_manager/) |
-| [Business Buy Goods](https://developer.safaricom.co.ke/APIs/BusinessBuyGoods ) | `b2b`  | Stable ✅ | [business buy goods example](/docs/client/b2b.md) |
-| [Business Pay Bill](https://developer.safaricom.co.ke/APIs/BusinessPayBill) | N/A | Unimplemented | N/A |
-| [Business To Customer (B2C)](https://developer.safaricom.co.ke/APIs/BusinessToCustomer) | `b2c` | Stable ✅️ | [b2c example](/docs/client/b2c.md) |
-| [Customer To Business (Register URL)](https://developer.safaricom.co.ke/APIs/CustomerToBusinessRegisterURL) | `c2b_register` | Stable  ✅️ | [c2b register example](/docs/client/c2b_register.md) |
-| [Customer To Business (Simulate)](#) | `c2b_simulate` | Stable  ✅️ | [c2b simulate example](/docs/client/c2b_simulate.md) |
-| [Dynamic QR](https://developer.safaricom.co.ke/APIs/DynamicQRCode) | `dynamic_qr` | Stable  ✅️ | [dynamic qr example](/docs/client/dynamic_qr.md) |
-| [M-PESA Express (Query)](https://developer.safaricom.co.ke/APIs/MpesaExpressQuery) | N/A | Unimplemented ️| N/A |
-| [M-PESA Express (Simulate)/ STK push](https://developer.safaricom.co.ke/APIs/MpesaExpressSimulate) | `express_request` | Stable  ✅️ | [express request example](/docs/client/express_request.md) |
-| [Transaction Status](https://developer.safaricom.co.ke/APIs/TransactionStatus) | `transaction_status` | Stable  ✅️ | [transaction status example](/docs/client/transaction_status.md) |
-| [Transaction Reversal](https://developer.safaricom.co.ke/APIs/Reversal) | `transaction_reversal` | Stable  ✅️ | [transaction reversal example](/docs/client/transaction_reversal.md) |
-| [Tax Remittance](https://developer.safaricom.co.ke/APIs/TaxRemittance ) | N/A | Unimplemented | N/A |
+| API                                                                                                         | Cargo Feature          | Status          | Example                                                              |
+| ----------------------------------------------------------------------------------------------------------- | ---------------------- | --------------- | -------------------------------------------------------------------- |
+| [Account Balance](https://developer.safaricom.co.ke/APIs/AccountBalance)                                    | `account_balance`      | Stable ✅       | [account balance example](/docs/client/account_balance.md)           |
+| [B2B Express Checkout](https://developer.safaricom.co.ke/APIs/B2BExpressCheckout)                           | N/A                    | Unimplemented   | N/A                                                                  |
+| [Bill Manager](https://developer.safaricom.co.ke/APIs/BillManager)                                          | `bill_manager`         | Unstable ⚠️     | [bill manager examples](/docs/client/bill_manager/)                  |
+| [Business Buy Goods](https://developer.safaricom.co.ke/APIs/BusinessBuyGoods)                               | `b2b`                  | Stable ✅       | [business buy goods example](/docs/client/b2b.md)                    |
+| [Business Pay Bill](https://developer.safaricom.co.ke/APIs/BusinessPayBill)                                 | N/A                    | Unimplemented   | N/A                                                                  |
+| [Business To Customer (B2C)](https://developer.safaricom.co.ke/APIs/BusinessToCustomer)                     | `b2c`                  | Stable ✅️      | [b2c example](/docs/client/b2c.md)                                   |
+| [Customer To Business (Register URL)](https://developer.safaricom.co.ke/APIs/CustomerToBusinessRegisterURL) | `c2b_register`         | Stable ✅️      | [c2b register example](/docs/client/c2b_register.md)                 |
+| [Customer To Business (Simulate)](#)                                                                        | `c2b_simulate`         | Stable ✅️      | [c2b simulate example](/docs/client/c2b_simulate.md)                 |
+| [Dynamic QR](https://developer.safaricom.co.ke/APIs/DynamicQRCode)                                          | `dynamic_qr`           | Stable ✅️      | [dynamic qr example](/docs/client/dynamic_qr.md)                     |
+| [M-PESA Express (Query)](https://developer.safaricom.co.ke/APIs/MpesaExpressQuery)                          | N/A                    | Unimplemented ️ | N/A                                                                  |
+| [M-PESA Express (Simulate)/ STK push](https://developer.safaricom.co.ke/APIs/MpesaExpressSimulate)          | `express_request`      | Stable ✅️      | [express request example](/docs/client/express_request.md)           |
+| [Transaction Status](https://developer.safaricom.co.ke/APIs/TransactionStatus)                              | `transaction_status`   | Stable ✅️      | [transaction status example](/docs/client/transaction_status.md)     |
+| [Transaction Reversal](https://developer.safaricom.co.ke/APIs/Reversal)                                     | `transaction_reversal` | Stable ✅️      | [transaction reversal example](/docs/client/transaction_reversal.md) |
+| [Tax Remittance](https://developer.safaricom.co.ke/APIs/TaxRemittance)                                      | N/A                    | Unimplemented   | N/A                                                                  |
 
 ## Author
 
 **Collins Muriuki**
 
-- Twitter: [@c12i_](https://twitter.com/c12i_)
-- Not affiliated with Safaricom.
+-   Twitter: [@c12i\_](https://twitter.com/c12i_)
+-   Not affiliated with Safaricom.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An unofficial Rust wrapper around the [Safaricom API](https://developer.safarico
 
 ```toml
 [dependencies]
-mpesa = { version = "1.1.0" }
+mpesa = { version = "1.2.0" }
 ```
 
 Optionally, you can disable default-features, which is basically the entire suite of MPESA APIs to conditionally select individual features. (See [Services](#services) table for the full list of Cargo features)
@@ -23,7 +23,7 @@ Example:
 
 ```toml
 [dependencies]
-mpesa = { version = "1.1.0", default_features = false, features = ["b2b", "express_request"] }
+mpesa = { version = "1.2.0", default_features = false, features = ["b2b", "express_request"] }
 ```
 
 In your lib or binary crate:


### PR DESCRIPTION
This MR overhauls how the release process is handled.

We now leverage [`release-plz`](https://release-plz.ieni.dev) to handle crate releases and CHANGELOG generation.

## Proposed workflow.

1. **Run `release-pr` locally**: this involves running `release-plz release-pr` locally with a `GITHUB_TOKEN` (This action should ideally only be limited to repo maintainers). This should open a release PR with semver version bumps based on conventional commits prior to this PR via `git cliff` (handled automatically) by `release-plz`
2. **Push release tag**: Same as what was done before, run `git tag v*` locally and push the tag.
3. **Draft Release**: Draft a release for the pushed tag. The content of this release can be derived from the generated CHANGELOG from `release-plz`.
4. **Publish release**: Publish the draft release to trigger the release ci workflow that will now publish the crate to `crates.io` and run other workflows i.e update gh pages docs.

## Caveats
- `release-plz` assumes the repository follows conventional commits in order to determine whether a `patch`, `minor` or `major` bump is required, as well as to generate changelog content. Conventional commits are currently not enforced for this repo, we will therefore need to adopt them to allow for seamless releases. The `CONTRIBUTING.md` guide has been updated with this info.
- What does this mean for the upcoming release. `1.2.0`? We will skip **step 1 (Initialize `release-pr` locally)** of the proposed workflow since there are no historical conventional commits for `release-plz` to generate a CHANGELOG and bump version from.
