### PR TITLE
Minor improvements and less lifetime & generic type noise

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -56,8 +56,8 @@ impl std::fmt::Display for AuthenticationResponse {
 
 #[cfg(test)]
 mod tests {
-    use wiremock::{Mock, MockServer};
     use crate::ApiEnvironment;
+    use wiremock::{Mock, MockServer};
 
     use super::*;
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,7 +2,7 @@ use cached::proc_macro::cached;
 use serde::{Deserialize, Serialize};
 use serde_aux::field_attributes::deserialize_number_from_string;
 
-use crate::{ApiEnvironment, Mpesa, MpesaError, MpesaResult, ResponseError};
+use crate::{Mpesa, MpesaError, MpesaResult, ResponseError};
 
 const AUTHENTICATION_URL: &str = "/oauth/v1/generate?grant_type=client_credentials";
 
@@ -13,8 +13,8 @@ const AUTHENTICATION_URL: &str = "/oauth/v1/generate?grant_type=client_credentia
     result = true,
     convert = r#"{ format!("{}", client.client_key()) }"#
 )]
-pub(crate) async fn auth(client: &Mpesa<impl ApiEnvironment>) -> MpesaResult<String> {
-    let url = format!("{}{}", client.environment.base_url(), AUTHENTICATION_URL);
+pub(crate) async fn auth(client: &Mpesa) -> MpesaResult<String> {
+    let url = format!("{}{}", client.base_url, AUTHENTICATION_URL);
 
     let response = client
         .http_client
@@ -57,6 +57,7 @@ impl std::fmt::Display for AuthenticationResponse {
 #[cfg(test)]
 mod tests {
     use wiremock::{Mock, MockServer};
+    use crate::ApiEnvironment;
 
     use super::*;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -294,7 +294,7 @@ impl Mpesa {
     /// Sends a request to the Safaricom API
     /// This method is used by all the builders to send requests to the
     /// Safaricom API
-    pub(crate) async fn send<Req, Res>(&self, req: Request<'_, Req>) -> MpesaResult<Res>
+    pub(crate) async fn send<Req, Res>(&self, req: Request<Req>) -> MpesaResult<Res>
     where
         Req: Serialize + Send,
         Res: DeserializeOwned,
@@ -321,9 +321,9 @@ impl Mpesa {
     }
 }
 
-pub struct Request<'a, Body: Serialize + Send> {
+pub struct Request<Body: Serialize + Send> {
     pub method: reqwest::Method,
-    pub path: &'a str,
+    pub path: &'static str,
     pub body: Body,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -35,7 +35,7 @@ pub struct Mpesa {
     pub(crate) http_client: HttpClient,
 }
 
-impl<'mpesa> Mpesa {
+impl Mpesa {
     /// Constructs a new `Mpesa` client.
     ///
     /// # Example
@@ -82,9 +82,10 @@ impl<'mpesa> Mpesa {
 
     /// Gets the initiator password
     /// If `None`, the default password is `"Safcom496!"`
-    pub(crate) fn initiator_password(&'mpesa self) -> String {
+    pub(crate) fn initiator_password(&self) -> String {
         self.initiator_password
             .borrow()
+            .as_ref()
             .map(|password| password.expose_secret().into())
             .unwrap_or(DEFAULT_INITIATOR_PASSWORD.to_owned())
     }
@@ -167,103 +168,103 @@ impl<'mpesa> Mpesa {
 
     #[cfg(feature = "b2c")]
     #[doc = include_str!("../docs/client/b2c.md")]
-    pub fn b2c(&'mpesa self, initiator_name: &'mpesa str) -> B2cBuilder<'mpesa> {
+    pub fn b2c<'a>(&'a self, initiator_name: &'a str) -> B2cBuilder {
         B2cBuilder::new(self, initiator_name)
     }
 
     #[cfg(feature = "b2b")]
     #[doc = include_str!("../docs/client/b2b.md")]
-    pub fn b2b(&'mpesa self, initiator_name: &'mpesa str) -> B2bBuilder<'mpesa> {
+    pub fn b2b<'a>(&'a self, initiator_name: &'a str) -> B2bBuilder {
         B2bBuilder::new(self, initiator_name)
     }
 
     #[cfg(feature = "bill_manager")]
     #[doc = include_str!("../docs/client/bill_manager/onboard.md")]
-    pub fn onboard(&'mpesa self) -> OnboardBuilder<'mpesa> {
+    pub fn onboard(&self) -> OnboardBuilder {
         OnboardBuilder::new(self)
     }
 
     #[cfg(feature = "bill_manager")]
     #[doc = include_str!("../docs/client/bill_manager/onboard_modify.md")]
-    pub fn onboard_modify(&'mpesa self) -> OnboardModifyBuilder<'mpesa> {
+    pub fn onboard_modify(&self) -> OnboardModifyBuilder {
         OnboardModifyBuilder::new(self)
     }
 
     #[cfg(feature = "bill_manager")]
     #[doc = include_str!("../docs/client/bill_manager/bulk_invoice.md")]
-    pub fn bulk_invoice(&'mpesa self) -> BulkInvoiceBuilder<'mpesa> {
+    pub fn bulk_invoice(&self) -> BulkInvoiceBuilder {
         BulkInvoiceBuilder::new(self)
     }
 
     #[cfg(feature = "bill_manager")]
     #[doc = include_str!("../docs/client/bill_manager/single_invoice.md")]
-    pub fn single_invoice(&'mpesa self) -> SingleInvoiceBuilder<'mpesa,> {
+    pub fn single_invoice(&self) -> SingleInvoiceBuilder {
         SingleInvoiceBuilder::new(self)
     }
 
     #[cfg(feature = "bill_manager")]
     #[doc = include_str!("../docs/client/bill_manager/reconciliation.md")]
-    pub fn reconciliation(&'mpesa self) -> ReconciliationBuilder<'mpesa> {
+    pub fn reconciliation(&self) -> ReconciliationBuilder {
         ReconciliationBuilder::new(self)
     }
 
     #[cfg(feature = "bill_manager")]
     #[doc = include_str!("../docs/client/bill_manager/cancel_invoice.md")]
-    pub fn cancel_invoice(&'mpesa self) -> CancelInvoiceBuilder<'mpesa> {
+    pub fn cancel_invoice(&self) -> CancelInvoiceBuilder {
         CancelInvoiceBuilder::new(self)
     }
 
     #[cfg(feature = "c2b_register")]
     #[doc = include_str!("../docs/client/c2b_register.md")]
-    pub fn c2b_register(&'mpesa self) -> C2bRegisterBuilder<'mpesa> {
+    pub fn c2b_register(&self) -> C2bRegisterBuilder {
         C2bRegisterBuilder::new(self)
     }
 
     #[cfg(feature = "c2b_simulate")]
     #[doc = include_str!("../docs/client/c2b_simulate.md")]
-    pub fn c2b_simulate(&'mpesa self) -> C2bSimulateBuilder<'mpesa> {
+    pub fn c2b_simulate(&self) -> C2bSimulateBuilder {
         C2bSimulateBuilder::new(self)
     }
 
     #[cfg(feature = "account_balance")]
     #[doc = include_str!("../docs/client/account_balance.md")]
-    pub fn account_balance(
-        &'mpesa self,
-        initiator_name: &'mpesa str,
-    ) -> AccountBalanceBuilder<'mpesa> {
+    pub fn account_balance<'a>(
+        &'a self,
+        initiator_name: &'a str,
+    ) -> AccountBalanceBuilder {
         AccountBalanceBuilder::new(self, initiator_name)
     }
 
     #[cfg(feature = "express_request")]
     #[doc = include_str!("../docs/client/express_request.md")]
-    pub fn express_request(
-        &'mpesa self,
-        business_short_code: &'mpesa str,
-    ) -> MpesaExpressRequestBuilder<'mpesa> {
+    pub fn express_request<'a >(
+        &'a self,
+        business_short_code: &'a str,
+    ) -> MpesaExpressRequestBuilder {
         MpesaExpressRequestBuilder::new(self, business_short_code)
     }
 
     #[cfg(feature = "transaction_reversal")]
     #[doc = include_str!("../docs/client/transaction_reversal.md")]
-    pub fn transaction_reversal(
-        &'mpesa self,
-        initiator_name: &'mpesa str,
-    ) -> TransactionReversalBuilder<'mpesa> {
+    pub fn transaction_reversal<'a>(
+        &'a self,
+        initiator_name: &'a str,
+    ) -> TransactionReversalBuilder {
         TransactionReversalBuilder::new(self, initiator_name)
     }
 
     #[cfg(feature = "transaction_status")]
     #[doc = include_str!("../docs/client/transaction_status.md")]
-    pub fn transaction_status(
-        &'mpesa self,
-        initiator_name: &'mpesa str,
-    ) -> TransactionStatusBuilder<'mpesa> {
+    pub fn transaction_status<'a>(
+        &'a self,
+        initiator_name: &'a str,
+    ) -> TransactionStatusBuilder {
         TransactionStatusBuilder::new(self, initiator_name)
     }
 
     #[cfg(feature = "dynamic_qr")]
     #[doc = include_str!("../docs/client/dynamic_qr.md")]
-    pub fn dynamic_qr(&'mpesa self) -> DynamicQRBuilder<'mpesa> {
+    pub fn dynamic_qr(&self) -> DynamicQRBuilder {
         DynamicQR::builder(self)
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,7 +30,7 @@ pub struct Mpesa {
     client_key: String,
     client_secret: Secret<String>,
     initiator_password: RefCell<Option<Secret<String>>>,
-    pub (crate) base_url: String,
+    pub(crate) base_url: String,
     certificate: String,
     pub(crate) http_client: HttpClient,
 }
@@ -58,7 +58,11 @@ impl Mpesa {
     /// ```
     /// # Panics
     /// This method can panic if a TLS backend cannot be initialized for the internal http_client
-    pub fn new<S: Into<String>>(client_key: S, client_secret: S, environment: impl ApiEnvironment) -> Self {
+    pub fn new<S: Into<String>>(
+        client_key: S,
+        client_secret: S,
+        environment: impl ApiEnvironment,
+    ) -> Self {
         let http_client = HttpClient::builder()
             .connect_timeout(std::time::Duration::from_millis(10_000))
             .user_agent(format!("mpesa-rust@{CARGO_PACKAGE_VERSION}"))
@@ -228,16 +232,13 @@ impl Mpesa {
 
     #[cfg(feature = "account_balance")]
     #[doc = include_str!("../docs/client/account_balance.md")]
-    pub fn account_balance<'a>(
-        &'a self,
-        initiator_name: &'a str,
-    ) -> AccountBalanceBuilder {
+    pub fn account_balance<'a>(&'a self, initiator_name: &'a str) -> AccountBalanceBuilder {
         AccountBalanceBuilder::new(self, initiator_name)
     }
 
     #[cfg(feature = "express_request")]
     #[doc = include_str!("../docs/client/express_request.md")]
-    pub fn express_request<'a >(
+    pub fn express_request<'a>(
         &'a self,
         business_short_code: &'a str,
     ) -> MpesaExpressRequestBuilder {
@@ -255,10 +256,7 @@ impl Mpesa {
 
     #[cfg(feature = "transaction_status")]
     #[doc = include_str!("../docs/client/transaction_status.md")]
-    pub fn transaction_status<'a>(
-        &'a self,
-        initiator_name: &'a str,
-    ) -> TransactionStatusBuilder {
+    pub fn transaction_status<'a>(&'a self, initiator_name: &'a str) -> TransactionStatusBuilder {
         TransactionStatusBuilder::new(self, initiator_name)
     }
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -45,7 +45,7 @@ impl TryFrom<&str> for Environment {
     type Error = MpesaError;
 
     fn try_from(v: &str) -> Result<Self, Self::Error> {
-         let v = v.to_lowercase();
+        let v = v.to_lowercase();
         match v.as_str() {
             "production" => Ok(Self::Production),
             "sandbox" => Ok(Self::Sandbox),

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -33,23 +33,11 @@ pub trait ApiEnvironment: Clone {
     fn get_certificate(&self) -> &str;
 }
 
-macro_rules! environment_from_string {
-    ($v:expr) => {
-        match $v {
-            "production" => Ok(Self::Production),
-            "sandbox" => Ok(Self::Sandbox),
-            _ => Err(MpesaError::Message(
-                "Could not parse the provided environment name",
-            )),
-        }
-    };
-}
-
 impl FromStr for Environment {
     type Err = MpesaError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        environment_from_string!(s.to_lowercase().as_str())
+        s.try_into()
     }
 }
 
@@ -57,7 +45,14 @@ impl TryFrom<&str> for Environment {
     type Error = MpesaError;
 
     fn try_from(v: &str) -> Result<Self, Self::Error> {
-        environment_from_string!(v.to_lowercase().as_str())
+         let v = v.to_lowercase();
+        match v.as_str() {
+            "production" => Ok(Self::Production),
+            "sandbox" => Ok(Self::Sandbox),
+            _ => Err(MpesaError::Message(
+                "Could not parse the provided environment name",
+            )),
+        }
     }
 }
 
@@ -65,7 +60,7 @@ impl TryFrom<String> for Environment {
     type Error = MpesaError;
 
     fn try_from(v: String) -> Result<Self, Self::Error> {
-        environment_from_string!(v.to_lowercase().as_str())
+        v.as_str().try_into()
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,11 +9,11 @@ use thiserror::Error;
 pub enum MpesaError {
     #[error("Service error: {0}")]
     Service(ResponseError),
-    #[error("An error has occured while performing the http request")]
+    #[error("An error has occurred while performing the http request")]
     NetworkError(#[from] reqwest::Error),
-    #[error("An error has occured while serializing/ deserializing")]
+    #[error("An error has occurred while serializing/ deserializing")]
     ParseError(#[from] serde_json::Error),
-    #[error("An error has occured while retrieving an environmental variable")]
+    #[error("An error has occurred while retrieving an environmental variable")]
     EnvironmentalVariableError(#[from] VarError),
     #[error("An error has occurred while generating security credentials")]
     EncryptionError(#[from] openssl::error::ErrorStack),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,9 +11,9 @@ pub enum MpesaError {
     Service(ResponseError),
     #[error("An error has occured while performing the http request")]
     NetworkError(#[from] reqwest::Error),
-    #[error("An error has occured while serializig/ deserializing")]
+    #[error("An error has occured while serializing/ deserializing")]
     ParseError(#[from] serde_json::Error),
-    #[error("An error has occured while retreiving an environmental variable")]
+    #[error("An error has occured while retrieving an environmental variable")]
     EnvironmentalVariableError(#[from] VarError),
     #[error("An error has occurred while generating security credentials")]
     EncryptionError(#[from] openssl::error::ErrorStack),

--- a/src/services/account_balance.rs
+++ b/src/services/account_balance.rs
@@ -3,7 +3,6 @@
 use serde::{Deserialize, Serialize};
 
 use crate::constants::{CommandId, IdentifierTypes};
-use crate::environment::ApiEnvironment;
 use crate::{Mpesa, MpesaError, MpesaResult};
 
 const ACCOUNT_BALANCE_URL: &str = "mpesa/accountbalance/v1/query";
@@ -41,9 +40,9 @@ pub struct AccountBalanceResponse {
     pub response_description: String,
 }
 #[derive(Debug)]
-pub struct AccountBalanceBuilder<'mpesa, Env: ApiEnvironment> {
+pub struct AccountBalanceBuilder<'mpesa> {
     initiator_name: &'mpesa str,
-    client: &'mpesa Mpesa<Env>,
+    client: &'mpesa Mpesa,
     command_id: Option<CommandId>,
     party_a: Option<&'mpesa str>,
     identifier_type: Option<IdentifierTypes>,
@@ -52,13 +51,13 @@ pub struct AccountBalanceBuilder<'mpesa, Env: ApiEnvironment> {
     result_url: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> AccountBalanceBuilder<'mpesa, Env> {
+impl<'mpesa> AccountBalanceBuilder<'mpesa> {
     /// Creates a new `AccountBalanceBuilder`.
     /// Requires an `initiator_name`, the credential/ username used to authenticate the transaction request
     pub fn new(
-        client: &'mpesa Mpesa<Env>,
+        client: &'mpesa Mpesa,
         initiator_name: &'mpesa str,
-    ) -> AccountBalanceBuilder<'mpesa, Env> {
+    ) -> AccountBalanceBuilder<'mpesa> {
         AccountBalanceBuilder {
             initiator_name,
             client,
@@ -76,7 +75,7 @@ impl<'mpesa, Env: ApiEnvironment> AccountBalanceBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `CommandId` is invalid
-    pub fn command_id(mut self, command_id: CommandId) -> AccountBalanceBuilder<'mpesa, Env> {
+    pub fn command_id(mut self, command_id: CommandId) -> AccountBalanceBuilder<'mpesa> {
         self.command_id = Some(command_id);
         self
     }
@@ -86,7 +85,7 @@ impl<'mpesa, Env: ApiEnvironment> AccountBalanceBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `Party A` is not provided or invalid
-    pub fn party_a(mut self, party_a: &'mpesa str) -> AccountBalanceBuilder<'mpesa, Env> {
+    pub fn party_a(mut self, party_a: &'mpesa str) -> AccountBalanceBuilder<'mpesa> {
         self.party_a = Some(party_a);
         self
     }
@@ -99,14 +98,14 @@ impl<'mpesa, Env: ApiEnvironment> AccountBalanceBuilder<'mpesa, Env> {
     pub fn identifier_type(
         mut self,
         identifier_type: IdentifierTypes,
-    ) -> AccountBalanceBuilder<'mpesa, Env> {
+    ) -> AccountBalanceBuilder<'mpesa> {
         self.identifier_type = Some(identifier_type);
         self
     }
 
     /// Adds `Remarks`, a comment sent along transaction.
     /// Optional field that defaults to `"None"` if no value is provided
-    pub fn remarks(mut self, remarks: &'mpesa str) -> AccountBalanceBuilder<'mpesa, Env> {
+    pub fn remarks(mut self, remarks: &'mpesa str) -> AccountBalanceBuilder<'mpesa> {
         self.remarks = Some(remarks);
         self
     }
@@ -115,7 +114,7 @@ impl<'mpesa, Env: ApiEnvironment> AccountBalanceBuilder<'mpesa, Env> {
     ///
     /// # Error
     /// If `QueueTimeoutUrl` is invalid or not provided
-    pub fn timeout_url(mut self, timeout_url: &'mpesa str) -> AccountBalanceBuilder<'mpesa, Env> {
+    pub fn timeout_url(mut self, timeout_url: &'mpesa str) -> AccountBalanceBuilder<'mpesa> {
         self.queue_timeout_url = Some(timeout_url);
         self
     }
@@ -124,7 +123,7 @@ impl<'mpesa, Env: ApiEnvironment> AccountBalanceBuilder<'mpesa, Env> {
     ///
     /// # Error
     /// If `ResultUrl` is invalid or not provided
-    pub fn result_url(mut self, result_url: &'mpesa str) -> AccountBalanceBuilder<'mpesa, Env> {
+    pub fn result_url(mut self, result_url: &'mpesa str) -> AccountBalanceBuilder<'mpesa> {
         self.result_url = Some(result_url);
         self
     }
@@ -138,7 +137,7 @@ impl<'mpesa, Env: ApiEnvironment> AccountBalanceBuilder<'mpesa, Env> {
         mut self,
         timeout_url: &'mpesa str,
         result_url: &'mpesa str,
-    ) -> AccountBalanceBuilder<'mpesa, Env> {
+    ) -> AccountBalanceBuilder<'mpesa> {
         self.queue_timeout_url = Some(timeout_url);
         self.result_url = Some(result_url);
         self

--- a/src/services/b2b.rs
+++ b/src/services/b2b.rs
@@ -129,11 +129,7 @@ impl<'mpesa> B2bBuilder<'mpesa> {
     /// # Errors
     /// If either `Party A` or `Party B` is invalid or not provided
     #[deprecated]
-    pub fn parties(
-        mut self,
-        party_a: &'mpesa str,
-        party_b: &'mpesa str,
-    ) -> B2bBuilder<'mpesa> {
+    pub fn parties(mut self, party_a: &'mpesa str, party_b: &'mpesa str) -> B2bBuilder<'mpesa> {
         self.party_a = Some(party_a);
         self.party_b = Some(party_b);
         self
@@ -162,11 +158,7 @@ impl<'mpesa> B2bBuilder<'mpesa> {
     /// # Error
     /// If either `QueueTimeoutUrl` and `ResultUrl` is invalid or not provided
     #[deprecated]
-    pub fn urls(
-        mut self,
-        timeout_url: &'mpesa str,
-        result_url: &'mpesa str,
-    ) -> B2bBuilder<'mpesa> {
+    pub fn urls(mut self, timeout_url: &'mpesa str, result_url: &'mpesa str) -> B2bBuilder<'mpesa> {
         // TODO: validate urls
         self.queue_timeout_url = Some(timeout_url);
         self.result_url = Some(result_url);

--- a/src/services/b2b.rs
+++ b/src/services/b2b.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::client::Mpesa;
 use crate::constants::{CommandId, IdentifierTypes};
-use crate::environment::ApiEnvironment;
 use crate::errors::{MpesaError, MpesaResult};
 
 const B2B_URL: &str = "mpesa/b2b/v1/paymentrequest";
@@ -60,9 +59,9 @@ pub struct B2bResponse {
 
 #[derive(Debug)]
 /// B2B transaction builder struct
-pub struct B2bBuilder<'mpesa, Env: ApiEnvironment> {
+pub struct B2bBuilder<'mpesa> {
     initiator_name: &'mpesa str,
-    client: &'mpesa Mpesa<Env>,
+    client: &'mpesa Mpesa,
     command_id: Option<CommandId>,
     amount: Option<f64>,
     party_a: Option<&'mpesa str>,
@@ -75,10 +74,10 @@ pub struct B2bBuilder<'mpesa, Env: ApiEnvironment> {
     account_ref: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> B2bBuilder<'mpesa, Env> {
+impl<'mpesa> B2bBuilder<'mpesa> {
     /// Creates a new B2B builder
     /// Requires an `initiator_name`, the credential/ username used to authenticate the transaction request
-    pub fn new(client: &'mpesa Mpesa<Env>, initiator_name: &'mpesa str) -> B2bBuilder<'mpesa, Env> {
+    pub fn new(client: &'mpesa Mpesa, initiator_name: &'mpesa str) -> B2bBuilder<'mpesa> {
         B2bBuilder {
             client,
             initiator_name,
@@ -99,7 +98,7 @@ impl<'mpesa, Env: ApiEnvironment> B2bBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If invalid `CommandId` is provided
-    pub fn command_id(mut self, command_id: CommandId) -> B2bBuilder<'mpesa, Env> {
+    pub fn command_id(mut self, command_id: CommandId) -> B2bBuilder<'mpesa> {
         self.command_id = Some(command_id);
         self
     }
@@ -109,7 +108,7 @@ impl<'mpesa, Env: ApiEnvironment> B2bBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `Party A` is invalid or not provided
-    pub fn party_a(mut self, party_a: &'mpesa str) -> B2bBuilder<'mpesa, Env> {
+    pub fn party_a(mut self, party_a: &'mpesa str) -> B2bBuilder<'mpesa> {
         self.party_a = Some(party_a);
         self
     }
@@ -119,7 +118,7 @@ impl<'mpesa, Env: ApiEnvironment> B2bBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `Party B` is invalid or not provided
-    pub fn party_b(mut self, party_b: &'mpesa str) -> B2bBuilder<'mpesa, Env> {
+    pub fn party_b(mut self, party_b: &'mpesa str) -> B2bBuilder<'mpesa> {
         self.party_b = Some(party_b);
         self
     }
@@ -134,7 +133,7 @@ impl<'mpesa, Env: ApiEnvironment> B2bBuilder<'mpesa, Env> {
         mut self,
         party_a: &'mpesa str,
         party_b: &'mpesa str,
-    ) -> B2bBuilder<'mpesa, Env> {
+    ) -> B2bBuilder<'mpesa> {
         self.party_a = Some(party_a);
         self.party_b = Some(party_b);
         self
@@ -144,7 +143,7 @@ impl<'mpesa, Env: ApiEnvironment> B2bBuilder<'mpesa, Env> {
     ///
     /// # Error
     /// If `QueueTimeoutUrl` is invalid or not provided
-    pub fn timeout_url(mut self, timeout_url: &'mpesa str) -> B2bBuilder<'mpesa, Env> {
+    pub fn timeout_url(mut self, timeout_url: &'mpesa str) -> B2bBuilder<'mpesa> {
         self.queue_timeout_url = Some(timeout_url);
         self
     }
@@ -153,7 +152,7 @@ impl<'mpesa, Env: ApiEnvironment> B2bBuilder<'mpesa, Env> {
     ///
     /// # Error
     /// If `ResultUrl` is invalid or not provided
-    pub fn result_url(mut self, result_url: &'mpesa str) -> B2bBuilder<'mpesa, Env> {
+    pub fn result_url(mut self, result_url: &'mpesa str) -> B2bBuilder<'mpesa> {
         self.result_url = Some(result_url);
         self
     }
@@ -167,7 +166,7 @@ impl<'mpesa, Env: ApiEnvironment> B2bBuilder<'mpesa, Env> {
         mut self,
         timeout_url: &'mpesa str,
         result_url: &'mpesa str,
-    ) -> B2bBuilder<'mpesa, Env> {
+    ) -> B2bBuilder<'mpesa> {
         // TODO: validate urls
         self.queue_timeout_url = Some(timeout_url);
         self.result_url = Some(result_url);
@@ -175,19 +174,19 @@ impl<'mpesa, Env: ApiEnvironment> B2bBuilder<'mpesa, Env> {
     }
 
     /// Adds `sender_id`. Will default to `IdentifierTypes::ShortCode` if not explicitly provided
-    pub fn sender_id(mut self, sender_id: IdentifierTypes) -> B2bBuilder<'mpesa, Env> {
+    pub fn sender_id(mut self, sender_id: IdentifierTypes) -> B2bBuilder<'mpesa> {
         self.sender_id = Some(sender_id);
         self
     }
 
     /// Adds `receiver_id`. Will default to `IdentifierTypes::ShortCode` if not explicitly provided
-    pub fn receiver_id(mut self, receiver_id: IdentifierTypes) -> B2bBuilder<'mpesa, Env> {
+    pub fn receiver_id(mut self, receiver_id: IdentifierTypes) -> B2bBuilder<'mpesa> {
         self.receiver_id = Some(receiver_id);
         self
     }
 
     /// Adds `account_ref`. This field is required
-    pub fn account_ref(mut self, account_ref: &'mpesa str) -> B2bBuilder<'mpesa, Env> {
+    pub fn account_ref(mut self, account_ref: &'mpesa str) -> B2bBuilder<'mpesa> {
         // TODO: add validation
         self.account_ref = Some(account_ref);
         self
@@ -195,13 +194,13 @@ impl<'mpesa, Env: ApiEnvironment> B2bBuilder<'mpesa, Env> {
 
     /// Adds an `amount` to the request
     /// This is a required field
-    pub fn amount<Number: Into<f64>>(mut self, amount: Number) -> B2bBuilder<'mpesa, Env> {
+    pub fn amount<Number: Into<f64>>(mut self, amount: Number) -> B2bBuilder<'mpesa> {
         self.amount = Some(amount.into());
         self
     }
 
     /// Adds `remarks`. This field is optional, will default to "None" if not explicitly passed
-    pub fn remarks(mut self, remarks: &'mpesa str) -> B2bBuilder<'mpesa, Env> {
+    pub fn remarks(mut self, remarks: &'mpesa str) -> B2bBuilder<'mpesa> {
         self.remarks = Some(remarks);
         self
     }

--- a/src/services/b2c.rs
+++ b/src/services/b2c.rs
@@ -2,7 +2,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::environment::ApiEnvironment;
 use crate::{CommandId, Mpesa, MpesaError, MpesaResult};
 
 const B2C_URL: &str = "mpesa/b2c/v1/paymentrequest";
@@ -46,9 +45,9 @@ pub struct B2cResponse {
 
 #[derive(Debug)]
 /// B2C transaction builder struct
-pub struct B2cBuilder<'mpesa, Env: ApiEnvironment> {
+pub struct B2cBuilder<'mpesa> {
     initiator_name: &'mpesa str,
-    client: &'mpesa Mpesa<Env>,
+    client: &'mpesa Mpesa,
     command_id: Option<CommandId>,
     amount: Option<f64>,
     party_a: Option<&'mpesa str>,
@@ -59,10 +58,10 @@ pub struct B2cBuilder<'mpesa, Env: ApiEnvironment> {
     occasion: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> B2cBuilder<'mpesa, Env> {
+impl<'mpesa> B2cBuilder<'mpesa> {
     /// Create a new B2C builder.
     /// Requires an `initiator_name`, the credential/ username used to authenticate the transaction request
-    pub fn new(client: &'mpesa Mpesa<Env>, initiator_name: &'mpesa str) -> B2cBuilder<'mpesa, Env> {
+    pub fn new(client: &'mpesa Mpesa, initiator_name: &'mpesa str) -> B2cBuilder<'mpesa> {
         B2cBuilder {
             client,
             initiator_name,
@@ -78,7 +77,7 @@ impl<'mpesa, Env: ApiEnvironment> B2cBuilder<'mpesa, Env> {
     }
 
     /// Adds the `CommandId`. Defaults to `CommandId::BusinessPayment` if not explicitly provided.
-    pub fn command_id(mut self, command_id: CommandId) -> B2cBuilder<'mpesa, Env> {
+    pub fn command_id(mut self, command_id: CommandId) -> B2cBuilder<'mpesa> {
         self.command_id = Some(command_id);
         self
     }
@@ -88,7 +87,7 @@ impl<'mpesa, Env: ApiEnvironment> B2cBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `Party A` is invalid or not provided
-    pub fn party_a(mut self, party_a: &'mpesa str) -> B2cBuilder<'mpesa, Env> {
+    pub fn party_a(mut self, party_a: &'mpesa str) -> B2cBuilder<'mpesa> {
         self.party_a = Some(party_a);
         self
     }
@@ -98,7 +97,7 @@ impl<'mpesa, Env: ApiEnvironment> B2cBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `Party B` is invalid or not provided
-    pub fn party_b(mut self, party_b: &'mpesa str) -> B2cBuilder<'mpesa, Env> {
+    pub fn party_b(mut self, party_b: &'mpesa str) -> B2cBuilder<'mpesa> {
         self.party_b = Some(party_b);
         self
     }
@@ -113,7 +112,7 @@ impl<'mpesa, Env: ApiEnvironment> B2cBuilder<'mpesa, Env> {
         mut self,
         party_a: &'mpesa str,
         party_b: &'mpesa str,
-    ) -> B2cBuilder<'mpesa, Env> {
+    ) -> B2cBuilder<'mpesa> {
         // TODO: add validation
         self.party_a = Some(party_a);
         self.party_b = Some(party_b);
@@ -121,20 +120,20 @@ impl<'mpesa, Env: ApiEnvironment> B2cBuilder<'mpesa, Env> {
     }
 
     /// Adds `Remarks`. This is an optional field, will default to "None" if not explicitly provided
-    pub fn remarks(mut self, remarks: &'mpesa str) -> B2cBuilder<'mpesa, Env> {
+    pub fn remarks(mut self, remarks: &'mpesa str) -> B2cBuilder<'mpesa> {
         self.remarks = Some(remarks);
         self
     }
 
     /// Adds `Occasion`. This is an optional field, will default to an empty string
-    pub fn occasion(mut self, occasion: &'mpesa str) -> B2cBuilder<'mpesa, Env> {
+    pub fn occasion(mut self, occasion: &'mpesa str) -> B2cBuilder<'mpesa> {
         self.occasion = Some(occasion);
         self
     }
 
     /// Adds an `amount` to the request
     /// This is a required field
-    pub fn amount<Number: Into<f64>>(mut self, amount: Number) -> B2cBuilder<'mpesa, Env> {
+    pub fn amount<Number: Into<f64>>(mut self, amount: Number) -> B2cBuilder<'mpesa> {
         self.amount = Some(amount.into());
         self
     }
@@ -143,7 +142,7 @@ impl<'mpesa, Env: ApiEnvironment> B2cBuilder<'mpesa, Env> {
     ///
     /// # Error
     /// If `QueueTimeoutUrl` is invalid or not provided
-    pub fn timeout_url(mut self, timeout_url: &'mpesa str) -> B2cBuilder<'mpesa, Env> {
+    pub fn timeout_url(mut self, timeout_url: &'mpesa str) -> B2cBuilder<'mpesa> {
         self.queue_timeout_url = Some(timeout_url);
         self
     }
@@ -152,7 +151,7 @@ impl<'mpesa, Env: ApiEnvironment> B2cBuilder<'mpesa, Env> {
     ///
     /// # Error
     /// If `ResultUrl` is invalid or not provided
-    pub fn result_url(mut self, result_url: &'mpesa str) -> B2cBuilder<'mpesa, Env> {
+    pub fn result_url(mut self, result_url: &'mpesa str) -> B2cBuilder<'mpesa> {
         self.result_url = Some(result_url);
         self
     }
@@ -166,7 +165,7 @@ impl<'mpesa, Env: ApiEnvironment> B2cBuilder<'mpesa, Env> {
         mut self,
         timeout_url: &'mpesa str,
         result_url: &'mpesa str,
-    ) -> B2cBuilder<'mpesa, Env> {
+    ) -> B2cBuilder<'mpesa> {
         // TODO: validate urls; will probably return a `Result` from this
         self.queue_timeout_url = Some(timeout_url);
         self.result_url = Some(result_url);

--- a/src/services/b2c.rs
+++ b/src/services/b2c.rs
@@ -108,11 +108,7 @@ impl<'mpesa> B2cBuilder<'mpesa> {
     /// # Errors
     /// If either `Party A` or `Party B` is invalid or not provided
     #[deprecated]
-    pub fn parties(
-        mut self,
-        party_a: &'mpesa str,
-        party_b: &'mpesa str,
-    ) -> B2cBuilder<'mpesa> {
+    pub fn parties(mut self, party_a: &'mpesa str, party_b: &'mpesa str) -> B2cBuilder<'mpesa> {
         // TODO: add validation
         self.party_a = Some(party_a);
         self.party_b = Some(party_b);
@@ -161,11 +157,7 @@ impl<'mpesa> B2cBuilder<'mpesa> {
     /// # Error
     /// If either `QueueTimeoutUrl` and `ResultUrl` is invalid or not provided
     #[deprecated]
-    pub fn urls(
-        mut self,
-        timeout_url: &'mpesa str,
-        result_url: &'mpesa str,
-    ) -> B2cBuilder<'mpesa> {
+    pub fn urls(mut self, timeout_url: &'mpesa str, result_url: &'mpesa str) -> B2cBuilder<'mpesa> {
         // TODO: validate urls; will probably return a `Result` from this
         self.queue_timeout_url = Some(timeout_url);
         self.result_url = Some(result_url);

--- a/src/services/bill_manager/bulk_invoice.rs
+++ b/src/services/bill_manager/bulk_invoice.rs
@@ -4,7 +4,6 @@ use serde::Deserialize;
 
 use crate::client::Mpesa;
 use crate::constants::Invoice;
-use crate::environment::ApiEnvironment;
 use crate::errors::{MpesaError, MpesaResult};
 
 const BILL_MANAGER_BULK_INVOICE_API_URL: &str = "v1/billmanager-invoice/bulk-invoicing";
@@ -20,14 +19,14 @@ pub struct BulkInvoiceResponse {
 }
 
 #[derive(Debug)]
-pub struct BulkInvoiceBuilder<'mpesa, Env: ApiEnvironment> {
-    client: &'mpesa Mpesa<Env>,
+pub struct BulkInvoiceBuilder<'mpesa> {
+    client: &'mpesa Mpesa,
     invoices: Vec<Invoice<'mpesa>>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> BulkInvoiceBuilder<'mpesa, Env> {
+impl<'mpesa> BulkInvoiceBuilder<'mpesa> {
     /// Creates a new Bill Manager Bulk Invoice builder
-    pub fn new(client: &'mpesa Mpesa<Env>) -> BulkInvoiceBuilder<'mpesa, Env> {
+    pub fn new(client: &'mpesa Mpesa) -> BulkInvoiceBuilder<'mpesa> {
         BulkInvoiceBuilder {
             client,
             invoices: vec![],
@@ -35,7 +34,7 @@ impl<'mpesa, Env: ApiEnvironment> BulkInvoiceBuilder<'mpesa, Env> {
     }
 
     /// Adds a single `invoice`
-    pub fn invoice(mut self, invoice: Invoice<'mpesa>) -> BulkInvoiceBuilder<'mpesa, Env> {
+    pub fn invoice(mut self, invoice: Invoice<'mpesa>) -> BulkInvoiceBuilder<'mpesa> {
         self.invoices.push(invoice);
         self
     }
@@ -44,7 +43,7 @@ impl<'mpesa, Env: ApiEnvironment> BulkInvoiceBuilder<'mpesa, Env> {
     pub fn invoices(
         mut self,
         mut invoices: Vec<Invoice<'mpesa>>,
-    ) -> BulkInvoiceBuilder<'mpesa, Env> {
+    ) -> BulkInvoiceBuilder<'mpesa> {
         self.invoices.append(&mut invoices);
         self
     }

--- a/src/services/bill_manager/bulk_invoice.rs
+++ b/src/services/bill_manager/bulk_invoice.rs
@@ -40,10 +40,7 @@ impl<'mpesa> BulkInvoiceBuilder<'mpesa> {
     }
 
     /// Adds multiple `invoices`
-    pub fn invoices(
-        mut self,
-        mut invoices: Vec<Invoice<'mpesa>>,
-    ) -> BulkInvoiceBuilder<'mpesa> {
+    pub fn invoices(mut self, mut invoices: Vec<Invoice<'mpesa>>) -> BulkInvoiceBuilder<'mpesa> {
         self.invoices.append(&mut invoices);
         self
     }

--- a/src/services/bill_manager/cancel_invoice.rs
+++ b/src/services/bill_manager/cancel_invoice.rs
@@ -3,7 +3,6 @@
 use serde::{Deserialize, Serialize};
 
 use crate::client::Mpesa;
-use crate::environment::ApiEnvironment;
 use crate::errors::MpesaResult;
 
 const BILL_MANAGER_CANCEL_INVOICE_API_URL: &str = "v1/billmanager-invoice/cancel-single-invoice";
@@ -25,14 +24,14 @@ pub struct CancelInvoiceResponse {
 }
 
 #[derive(Debug)]
-pub struct CancelInvoiceBuilder<'mpesa, Env: ApiEnvironment> {
-    client: &'mpesa Mpesa<Env>,
+pub struct CancelInvoiceBuilder<'mpesa> {
+    client: &'mpesa Mpesa,
     external_references: Vec<CancelInvoicePayload<'mpesa>>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> CancelInvoiceBuilder<'mpesa, Env> {
+impl<'mpesa> CancelInvoiceBuilder<'mpesa> {
     /// Creates a new Bill Manager Cancel invoice builder
-    pub fn new(client: &'mpesa Mpesa<Env>) -> CancelInvoiceBuilder<'mpesa, Env> {
+    pub fn new(client: &'mpesa Mpesa) -> CancelInvoiceBuilder<'mpesa> {
         CancelInvoiceBuilder {
             client,
             external_references: vec![],
@@ -43,7 +42,7 @@ impl<'mpesa, Env: ApiEnvironment> CancelInvoiceBuilder<'mpesa, Env> {
     pub fn external_reference(
         mut self,
         external_reference: &'mpesa str,
-    ) -> CancelInvoiceBuilder<'mpesa, Env> {
+    ) -> CancelInvoiceBuilder<'mpesa> {
         self.external_references
             .push(CancelInvoicePayload { external_reference });
         self
@@ -53,7 +52,7 @@ impl<'mpesa, Env: ApiEnvironment> CancelInvoiceBuilder<'mpesa, Env> {
     pub fn external_references(
         mut self,
         external_references: Vec<&'mpesa str>,
-    ) -> CancelInvoiceBuilder<'mpesa, Env> {
+    ) -> CancelInvoiceBuilder<'mpesa> {
         self.external_references.append(
             &mut external_references
                 .into_iter()

--- a/src/services/bill_manager/onboard.rs
+++ b/src/services/bill_manager/onboard.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::client::Mpesa;
 use crate::constants::SendRemindersTypes;
-use crate::environment::ApiEnvironment;
 use crate::errors::{MpesaError, MpesaResult};
 
 const BILL_MANAGER_ONBOARD_API_URL: &str = "v1/billmanager-invoice/optin";
@@ -35,8 +34,8 @@ pub struct OnboardResponse {
 }
 
 #[derive(Debug)]
-pub struct OnboardBuilder<'mpesa, Env: ApiEnvironment> {
-    client: &'mpesa Mpesa<Env>,
+pub struct OnboardBuilder<'mpesa> {
+    client: &'mpesa Mpesa,
     callback_url: Option<&'mpesa str>,
     email: Option<&'mpesa str>,
     logo: Option<&'mpesa str>,
@@ -45,9 +44,9 @@ pub struct OnboardBuilder<'mpesa, Env: ApiEnvironment> {
     short_code: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> OnboardBuilder<'mpesa, Env> {
+impl<'mpesa> OnboardBuilder<'mpesa> {
     /// Creates a new Bill Manager Onboard builder
-    pub fn new(client: &'mpesa Mpesa<Env>) -> OnboardBuilder<'mpesa, Env> {
+    pub fn new(client: &'mpesa Mpesa) -> OnboardBuilder<'mpesa> {
         OnboardBuilder {
             client,
             callback_url: None,
@@ -63,7 +62,7 @@ impl<'mpesa, Env: ApiEnvironment> OnboardBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If 'callbackUrl` is not provided.
-    pub fn callback_url(mut self, callback_url: &'mpesa str) -> OnboardBuilder<'mpesa, Env> {
+    pub fn callback_url(mut self, callback_url: &'mpesa str) -> OnboardBuilder<'mpesa> {
         self.callback_url = Some(callback_url);
         self
     }
@@ -72,7 +71,7 @@ impl<'mpesa, Env: ApiEnvironment> OnboardBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `email` is not provided.
-    pub fn email(mut self, email: &'mpesa str) -> OnboardBuilder<'mpesa, Env> {
+    pub fn email(mut self, email: &'mpesa str) -> OnboardBuilder<'mpesa> {
         self.email = Some(email);
         self
     }
@@ -81,7 +80,7 @@ impl<'mpesa, Env: ApiEnvironment> OnboardBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `logo` is not provided.
-    pub fn logo(mut self, logo: &'mpesa str) -> OnboardBuilder<'mpesa, Env> {
+    pub fn logo(mut self, logo: &'mpesa str) -> OnboardBuilder<'mpesa> {
         self.logo = Some(logo);
         self
     }
@@ -93,7 +92,7 @@ impl<'mpesa, Env: ApiEnvironment> OnboardBuilder<'mpesa, Env> {
     pub fn official_contact(
         mut self,
         official_contact: &'mpesa str,
-    ) -> OnboardBuilder<'mpesa, Env> {
+    ) -> OnboardBuilder<'mpesa> {
         self.official_contact = Some(official_contact);
         self
     }
@@ -105,7 +104,7 @@ impl<'mpesa, Env: ApiEnvironment> OnboardBuilder<'mpesa, Env> {
     pub fn send_reminders(
         mut self,
         send_reminders: SendRemindersTypes,
-    ) -> OnboardBuilder<'mpesa, Env> {
+    ) -> OnboardBuilder<'mpesa> {
         self.send_reminders = Some(send_reminders);
         self
     }
@@ -114,7 +113,7 @@ impl<'mpesa, Env: ApiEnvironment> OnboardBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If Till or PayBill number is invalid or not provided
-    pub fn short_code(mut self, short_code: &'mpesa str) -> OnboardBuilder<'mpesa, Env> {
+    pub fn short_code(mut self, short_code: &'mpesa str) -> OnboardBuilder<'mpesa> {
         self.short_code = Some(short_code);
         self
     }

--- a/src/services/bill_manager/onboard.rs
+++ b/src/services/bill_manager/onboard.rs
@@ -89,10 +89,7 @@ impl<'mpesa> OnboardBuilder<'mpesa> {
     ///
     /// # Errors
     /// If `officialContact` is invalid or not provided.
-    pub fn official_contact(
-        mut self,
-        official_contact: &'mpesa str,
-    ) -> OnboardBuilder<'mpesa> {
+    pub fn official_contact(mut self, official_contact: &'mpesa str) -> OnboardBuilder<'mpesa> {
         self.official_contact = Some(official_contact);
         self
     }
@@ -101,10 +98,7 @@ impl<'mpesa> OnboardBuilder<'mpesa> {
     ///
     /// # Errors
     /// If `sendReminders` is not valid.
-    pub fn send_reminders(
-        mut self,
-        send_reminders: SendRemindersTypes,
-    ) -> OnboardBuilder<'mpesa> {
+    pub fn send_reminders(mut self, send_reminders: SendRemindersTypes) -> OnboardBuilder<'mpesa> {
         self.send_reminders = Some(send_reminders);
         self
     }

--- a/src/services/bill_manager/onboard_modify.rs
+++ b/src/services/bill_manager/onboard_modify.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::client::Mpesa;
 use crate::constants::SendRemindersTypes;
-use crate::environment::ApiEnvironment;
 use crate::errors::MpesaResult;
 
 const BILL_MANAGER_ONBOARD_MODIFY_API_URL: &str = "v1/billmanager-invoice/change-optin-details";
@@ -47,8 +46,8 @@ pub struct OnboardModifyResponse {
 }
 
 #[derive(Debug)]
-pub struct OnboardModifyBuilder<'mpesa, Env: ApiEnvironment> {
-    client: &'mpesa Mpesa<Env>,
+pub struct OnboardModifyBuilder<'mpesa> {
+    client: &'mpesa Mpesa,
     callback_url: Option<&'mpesa str>,
     email: Option<&'mpesa str>,
     logo: Option<&'mpesa str>,
@@ -57,9 +56,9 @@ pub struct OnboardModifyBuilder<'mpesa, Env: ApiEnvironment> {
     short_code: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> OnboardModifyBuilder<'mpesa, Env> {
+impl<'mpesa> OnboardModifyBuilder<'mpesa> {
     /// Creates a new Bill Manager Onboard Modify builder
-    pub fn new(client: &'mpesa Mpesa<Env>) -> OnboardModifyBuilder<'mpesa, Env> {
+    pub fn new(client: &'mpesa Mpesa) -> OnboardModifyBuilder<'mpesa> {
         OnboardModifyBuilder {
             client,
             callback_url: None,
@@ -72,19 +71,19 @@ impl<'mpesa, Env: ApiEnvironment> OnboardModifyBuilder<'mpesa, Env> {
     }
 
     /// Adds `callbackUrl`.
-    pub fn callback_url(mut self, callback_url: &'mpesa str) -> OnboardModifyBuilder<'mpesa, Env> {
+    pub fn callback_url(mut self, callback_url: &'mpesa str) -> OnboardModifyBuilder<'mpesa> {
         self.callback_url = Some(callback_url);
         self
     }
 
     /// Adds an `email` address to the request.
-    pub fn email(mut self, email: &'mpesa str) -> OnboardModifyBuilder<'mpesa, Env> {
+    pub fn email(mut self, email: &'mpesa str) -> OnboardModifyBuilder<'mpesa> {
         self.email = Some(email);
         self
     }
 
     /// Adds `logo`; a file with your organizions's logo.
-    pub fn logo(mut self, logo: &'mpesa str) -> OnboardModifyBuilder<'mpesa, Env> {
+    pub fn logo(mut self, logo: &'mpesa str) -> OnboardModifyBuilder<'mpesa> {
         self.logo = Some(logo);
         self
     }
@@ -93,7 +92,7 @@ impl<'mpesa, Env: ApiEnvironment> OnboardModifyBuilder<'mpesa, Env> {
     pub fn official_contact(
         mut self,
         official_contact: &'mpesa str,
-    ) -> OnboardModifyBuilder<'mpesa, Env> {
+    ) -> OnboardModifyBuilder<'mpesa> {
         self.official_contact = Some(official_contact);
         self
     }
@@ -102,13 +101,13 @@ impl<'mpesa, Env: ApiEnvironment> OnboardModifyBuilder<'mpesa, Env> {
     pub fn send_reminders(
         mut self,
         send_reminders: SendRemindersTypes,
-    ) -> OnboardModifyBuilder<'mpesa, Env> {
+    ) -> OnboardModifyBuilder<'mpesa> {
         self.send_reminders = Some(send_reminders);
         self
     }
 
     /// Adds `ShortCode`; the 6 digit MPESA Till Number or PayBill Number
-    pub fn short_code(mut self, short_code: &'mpesa str) -> OnboardModifyBuilder<'mpesa, Env> {
+    pub fn short_code(mut self, short_code: &'mpesa str) -> OnboardModifyBuilder<'mpesa> {
         self.short_code = Some(short_code);
         self
     }

--- a/src/services/bill_manager/reconciliation.rs
+++ b/src/services/bill_manager/reconciliation.rs
@@ -4,7 +4,6 @@ use chrono::prelude::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::client::Mpesa;
-use crate::environment::ApiEnvironment;
 use crate::errors::{MpesaError, MpesaResult};
 
 const BILL_MANAGER_RECONCILIATION_API_URL: &str = "v1/billmanager-invoice/reconciliation";
@@ -31,8 +30,8 @@ pub struct ReconciliationResponse {
 }
 
 #[derive(Debug)]
-pub struct ReconciliationBuilder<'mpesa, Env: ApiEnvironment> {
-    client: &'mpesa Mpesa<Env>,
+pub struct ReconciliationBuilder<'mpesa> {
+    client: &'mpesa Mpesa,
     account_reference: Option<&'mpesa str>,
     external_reference: Option<&'mpesa str>,
     full_name: Option<&'mpesa str>,
@@ -43,9 +42,9 @@ pub struct ReconciliationBuilder<'mpesa, Env: ApiEnvironment> {
     transaction_id: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> ReconciliationBuilder<'mpesa, Env> {
+impl<'mpesa> ReconciliationBuilder<'mpesa> {
     /// Creates a new Bill Manager Reconciliation Builder
-    pub fn new(client: &'mpesa Mpesa<Env>) -> ReconciliationBuilder<'mpesa, Env> {
+    pub fn new(client: &'mpesa Mpesa) -> ReconciliationBuilder<'mpesa> {
         ReconciliationBuilder {
             client,
             account_reference: None,
@@ -63,7 +62,7 @@ impl<'mpesa, Env: ApiEnvironment> ReconciliationBuilder<'mpesa, Env> {
     pub fn account_reference(
         mut self,
         account_reference: &'mpesa str,
-    ) -> ReconciliationBuilder<'mpesa, Env> {
+    ) -> ReconciliationBuilder<'mpesa> {
         self.account_reference = Some(account_reference);
         self
     }
@@ -72,19 +71,19 @@ impl<'mpesa, Env: ApiEnvironment> ReconciliationBuilder<'mpesa, Env> {
     pub fn external_reference(
         mut self,
         external_reference: &'mpesa str,
-    ) -> ReconciliationBuilder<'mpesa, Env> {
+    ) -> ReconciliationBuilder<'mpesa> {
         self.external_reference = Some(external_reference);
         self
     }
 
     /// Adds `full_name`
-    pub fn full_name(mut self, full_name: &'mpesa str) -> ReconciliationBuilder<'mpesa, Env> {
+    pub fn full_name(mut self, full_name: &'mpesa str) -> ReconciliationBuilder<'mpesa> {
         self.full_name = Some(full_name);
         self
     }
 
     /// Adds `invoice_name`
-    pub fn invoice_name(mut self, invoice_name: &'mpesa str) -> ReconciliationBuilder<'mpesa, Env> {
+    pub fn invoice_name(mut self, invoice_name: &'mpesa str) -> ReconciliationBuilder<'mpesa> {
         self.invoice_name = Some(invoice_name);
         self
     }
@@ -93,7 +92,7 @@ impl<'mpesa, Env: ApiEnvironment> ReconciliationBuilder<'mpesa, Env> {
     pub fn paid_amount<Number: Into<f64>>(
         mut self,
         paid_amount: Number,
-    ) -> ReconciliationBuilder<'mpesa, Env> {
+    ) -> ReconciliationBuilder<'mpesa> {
         self.paid_amount = Some(paid_amount.into());
         self
     }
@@ -102,13 +101,13 @@ impl<'mpesa, Env: ApiEnvironment> ReconciliationBuilder<'mpesa, Env> {
     pub fn payment_date(
         mut self,
         payment_date: DateTime<Utc>,
-    ) -> ReconciliationBuilder<'mpesa, Env> {
+    ) -> ReconciliationBuilder<'mpesa> {
         self.payment_date = Some(payment_date);
         self
     }
 
     /// Adds `phone_number`
-    pub fn phone_number(mut self, phone_number: &'mpesa str) -> ReconciliationBuilder<'mpesa, Env> {
+    pub fn phone_number(mut self, phone_number: &'mpesa str) -> ReconciliationBuilder<'mpesa> {
         self.phone_number = Some(phone_number);
         self
     }
@@ -117,7 +116,7 @@ impl<'mpesa, Env: ApiEnvironment> ReconciliationBuilder<'mpesa, Env> {
     pub fn transaction_id(
         mut self,
         transaction_id: &'mpesa str,
-    ) -> ReconciliationBuilder<'mpesa, Env> {
+    ) -> ReconciliationBuilder<'mpesa> {
         self.transaction_id = Some(transaction_id);
         self
     }

--- a/src/services/bill_manager/reconciliation.rs
+++ b/src/services/bill_manager/reconciliation.rs
@@ -98,10 +98,7 @@ impl<'mpesa> ReconciliationBuilder<'mpesa> {
     }
 
     /// Adds `payment_date`
-    pub fn payment_date(
-        mut self,
-        payment_date: DateTime<Utc>,
-    ) -> ReconciliationBuilder<'mpesa> {
+    pub fn payment_date(mut self, payment_date: DateTime<Utc>) -> ReconciliationBuilder<'mpesa> {
         self.payment_date = Some(payment_date);
         self
     }
@@ -113,10 +110,7 @@ impl<'mpesa> ReconciliationBuilder<'mpesa> {
     }
 
     /// Adds `transaction_id`
-    pub fn transaction_id(
-        mut self,
-        transaction_id: &'mpesa str,
-    ) -> ReconciliationBuilder<'mpesa> {
+    pub fn transaction_id(mut self, transaction_id: &'mpesa str) -> ReconciliationBuilder<'mpesa> {
         self.transaction_id = Some(transaction_id);
         self
     }

--- a/src/services/bill_manager/single_invoice.rs
+++ b/src/services/bill_manager/single_invoice.rs
@@ -51,10 +51,7 @@ impl<'mpesa> SingleInvoiceBuilder<'mpesa> {
     }
 
     /// Adds `amount`
-    pub fn amount<Number: Into<f64>>(
-        mut self,
-        amount: Number,
-    ) -> SingleInvoiceBuilder<'mpesa> {
+    pub fn amount<Number: Into<f64>>(mut self, amount: Number) -> SingleInvoiceBuilder<'mpesa> {
         self.amount = Some(amount.into());
         self
     }
@@ -78,10 +75,7 @@ impl<'mpesa> SingleInvoiceBuilder<'mpesa> {
     }
 
     /// Adds `billed_period`; must be in the format `"Month Year"` e.g. `"March 2023"`
-    pub fn billed_period(
-        mut self,
-        billed_period: &'mpesa str,
-    ) -> SingleInvoiceBuilder<'mpesa> {
+    pub fn billed_period(mut self, billed_period: &'mpesa str) -> SingleInvoiceBuilder<'mpesa> {
         self.billed_period = Some(billed_period);
         self
     }

--- a/src/services/bill_manager/single_invoice.rs
+++ b/src/services/bill_manager/single_invoice.rs
@@ -5,7 +5,6 @@ use serde::Deserialize;
 
 use crate::client::Mpesa;
 use crate::constants::{Invoice, InvoiceItem};
-use crate::environment::ApiEnvironment;
 use crate::errors::{MpesaError, MpesaResult};
 
 const BILL_MANAGER_SINGLE_INVOICE_API_URL: &str = "v1/billmanager-invoice/single-invoicing";
@@ -21,8 +20,8 @@ pub struct SingleInvoiceResponse {
 }
 
 #[derive(Debug)]
-pub struct SingleInvoiceBuilder<'mpesa, Env: ApiEnvironment> {
-    client: &'mpesa Mpesa<Env>,
+pub struct SingleInvoiceBuilder<'mpesa> {
+    client: &'mpesa Mpesa,
     amount: Option<f64>,
     account_reference: Option<&'mpesa str>,
     billed_full_name: Option<&'mpesa str>,
@@ -34,9 +33,9 @@ pub struct SingleInvoiceBuilder<'mpesa, Env: ApiEnvironment> {
     invoice_name: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> SingleInvoiceBuilder<'mpesa, Env> {
+impl<'mpesa> SingleInvoiceBuilder<'mpesa> {
     /// Creates a new Bill Manager Single Invoice Builder
-    pub fn new(client: &'mpesa Mpesa<Env>) -> SingleInvoiceBuilder<'mpesa, Env> {
+    pub fn new(client: &'mpesa Mpesa) -> SingleInvoiceBuilder<'mpesa> {
         SingleInvoiceBuilder {
             client,
             amount: None,
@@ -55,7 +54,7 @@ impl<'mpesa, Env: ApiEnvironment> SingleInvoiceBuilder<'mpesa, Env> {
     pub fn amount<Number: Into<f64>>(
         mut self,
         amount: Number,
-    ) -> SingleInvoiceBuilder<'mpesa, Env> {
+    ) -> SingleInvoiceBuilder<'mpesa> {
         self.amount = Some(amount.into());
         self
     }
@@ -64,7 +63,7 @@ impl<'mpesa, Env: ApiEnvironment> SingleInvoiceBuilder<'mpesa, Env> {
     pub fn account_reference(
         mut self,
         account_refernce: &'mpesa str,
-    ) -> SingleInvoiceBuilder<'mpesa, Env> {
+    ) -> SingleInvoiceBuilder<'mpesa> {
         self.account_reference = Some(account_refernce);
         self
     }
@@ -73,7 +72,7 @@ impl<'mpesa, Env: ApiEnvironment> SingleInvoiceBuilder<'mpesa, Env> {
     pub fn billed_full_name(
         mut self,
         billed_full_name: &'mpesa str,
-    ) -> SingleInvoiceBuilder<'mpesa, Env> {
+    ) -> SingleInvoiceBuilder<'mpesa> {
         self.billed_full_name = Some(billed_full_name);
         self
     }
@@ -82,7 +81,7 @@ impl<'mpesa, Env: ApiEnvironment> SingleInvoiceBuilder<'mpesa, Env> {
     pub fn billed_period(
         mut self,
         billed_period: &'mpesa str,
-    ) -> SingleInvoiceBuilder<'mpesa, Env> {
+    ) -> SingleInvoiceBuilder<'mpesa> {
         self.billed_period = Some(billed_period);
         self
     }
@@ -91,13 +90,13 @@ impl<'mpesa, Env: ApiEnvironment> SingleInvoiceBuilder<'mpesa, Env> {
     pub fn billed_phone_number(
         mut self,
         billed_phone_number: &'mpesa str,
-    ) -> SingleInvoiceBuilder<'mpesa, Env> {
+    ) -> SingleInvoiceBuilder<'mpesa> {
         self.billed_phone_number = Some(billed_phone_number);
         self
     }
 
     /// Adds `due_date`
-    pub fn due_date(mut self, due_date: DateTime<Utc>) -> SingleInvoiceBuilder<'mpesa, Env> {
+    pub fn due_date(mut self, due_date: DateTime<Utc>) -> SingleInvoiceBuilder<'mpesa> {
         self.due_date = Some(due_date);
         self
     }
@@ -106,7 +105,7 @@ impl<'mpesa, Env: ApiEnvironment> SingleInvoiceBuilder<'mpesa, Env> {
     pub fn external_reference(
         mut self,
         external_reference: &'mpesa str,
-    ) -> SingleInvoiceBuilder<'mpesa, Env> {
+    ) -> SingleInvoiceBuilder<'mpesa> {
         self.external_reference = Some(external_reference);
         self
     }
@@ -115,13 +114,13 @@ impl<'mpesa, Env: ApiEnvironment> SingleInvoiceBuilder<'mpesa, Env> {
     pub fn invoice_items(
         mut self,
         invoice_items: Vec<InvoiceItem<'mpesa>>,
-    ) -> SingleInvoiceBuilder<'mpesa, Env> {
+    ) -> SingleInvoiceBuilder<'mpesa> {
         self.invoice_items = Some(invoice_items);
         self
     }
 
     /// Adds `invoice_name`
-    pub fn invoice_name(mut self, invoice_name: &'mpesa str) -> SingleInvoiceBuilder<'mpesa, Env> {
+    pub fn invoice_name(mut self, invoice_name: &'mpesa str) -> SingleInvoiceBuilder<'mpesa> {
         self.invoice_name = Some(invoice_name);
         self
     }

--- a/src/services/c2b_register.rs
+++ b/src/services/c2b_register.rs
@@ -57,10 +57,7 @@ impl<'mpesa> C2bRegisterBuilder<'mpesa> {
     ///
     /// # Error
     /// If `ValidationURL` is invalid or not provided
-    pub fn validation_url(
-        mut self,
-        validation_url: &'mpesa str,
-    ) -> C2bRegisterBuilder<'mpesa> {
+    pub fn validation_url(mut self, validation_url: &'mpesa str) -> C2bRegisterBuilder<'mpesa> {
         self.validation_url = Some(validation_url);
         self
     }
@@ -69,10 +66,7 @@ impl<'mpesa> C2bRegisterBuilder<'mpesa> {
     ///
     /// # Error
     /// If `ConfirmationUrl` is invalid or not provided
-    pub fn confirmation_url(
-        mut self,
-        confirmation_url: &'mpesa str,
-    ) -> C2bRegisterBuilder<'mpesa> {
+    pub fn confirmation_url(mut self, confirmation_url: &'mpesa str) -> C2bRegisterBuilder<'mpesa> {
         self.confirmation_url = Some(confirmation_url);
         self
     }

--- a/src/services/c2b_register.rs
+++ b/src/services/c2b_register.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::client::Mpesa;
 use crate::constants::ResponseType;
-use crate::environment::ApiEnvironment;
 use crate::errors::{MpesaError, MpesaResult};
 
 const C2B_REGISTER_URL: &str = "mpesa/c2b/v1/registerurl";
@@ -34,17 +33,17 @@ pub struct C2bRegisterResponse {
 
 #[derive(Debug)]
 /// C2B Register builder
-pub struct C2bRegisterBuilder<'mpesa, Env: ApiEnvironment> {
-    client: &'mpesa Mpesa<Env>,
+pub struct C2bRegisterBuilder<'mpesa> {
+    client: &'mpesa Mpesa,
     validation_url: Option<&'mpesa str>,
     confirmation_url: Option<&'mpesa str>,
     response_type: Option<ResponseType>,
     short_code: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> C2bRegisterBuilder<'mpesa, Env> {
+impl<'mpesa> C2bRegisterBuilder<'mpesa> {
     /// Creates a new C2B Builder
-    pub fn new(client: &'mpesa Mpesa<Env>) -> C2bRegisterBuilder<'mpesa, Env> {
+    pub fn new(client: &'mpesa Mpesa) -> C2bRegisterBuilder<'mpesa> {
         C2bRegisterBuilder {
             client,
             validation_url: None,
@@ -61,7 +60,7 @@ impl<'mpesa, Env: ApiEnvironment> C2bRegisterBuilder<'mpesa, Env> {
     pub fn validation_url(
         mut self,
         validation_url: &'mpesa str,
-    ) -> C2bRegisterBuilder<'mpesa, Env> {
+    ) -> C2bRegisterBuilder<'mpesa> {
         self.validation_url = Some(validation_url);
         self
     }
@@ -73,13 +72,13 @@ impl<'mpesa, Env: ApiEnvironment> C2bRegisterBuilder<'mpesa, Env> {
     pub fn confirmation_url(
         mut self,
         confirmation_url: &'mpesa str,
-    ) -> C2bRegisterBuilder<'mpesa, Env> {
+    ) -> C2bRegisterBuilder<'mpesa> {
         self.confirmation_url = Some(confirmation_url);
         self
     }
 
     /// Adds `ResponseType` for timeout. Will default to `ResponseType::Complete` if not explicitly provided
-    pub fn response_type(mut self, response_type: ResponseType) -> C2bRegisterBuilder<'mpesa, Env> {
+    pub fn response_type(mut self, response_type: ResponseType) -> C2bRegisterBuilder<'mpesa> {
         self.response_type = Some(response_type);
         self
     }
@@ -88,7 +87,7 @@ impl<'mpesa, Env: ApiEnvironment> C2bRegisterBuilder<'mpesa, Env> {
     ///
     /// # Error
     /// If `ShortCode` is invalid or not provided
-    pub fn short_code(mut self, short_code: &'mpesa str) -> C2bRegisterBuilder<'mpesa, Env> {
+    pub fn short_code(mut self, short_code: &'mpesa str) -> C2bRegisterBuilder<'mpesa> {
         self.short_code = Some(short_code);
         self
     }

--- a/src/services/c2b_simulate.rs
+++ b/src/services/c2b_simulate.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::client::Mpesa;
 use crate::constants::CommandId;
-use crate::environment::ApiEnvironment;
 use crate::errors::{MpesaError, MpesaResult};
 
 const C2B_SIMULATE_URL: &str = "mpesa/c2b/v1/simulate";
@@ -41,8 +40,8 @@ pub struct C2bSimulateResponse {
 }
 
 #[derive(Debug)]
-pub struct C2bSimulateBuilder<'mpesa, Env: ApiEnvironment> {
-    client: &'mpesa Mpesa<Env>,
+pub struct C2bSimulateBuilder<'mpesa> {
+    client: &'mpesa Mpesa,
     command_id: Option<CommandId>,
     amount: Option<f64>,
     msisdn: Option<&'mpesa str>,
@@ -50,9 +49,9 @@ pub struct C2bSimulateBuilder<'mpesa, Env: ApiEnvironment> {
     short_code: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> C2bSimulateBuilder<'mpesa, Env> {
+impl<'mpesa> C2bSimulateBuilder<'mpesa> {
     /// Creates a new C2B Simulate builder
-    pub fn new(client: &'mpesa Mpesa<Env>) -> C2bSimulateBuilder<'mpesa, Env> {
+    pub fn new(client: &'mpesa Mpesa) -> C2bSimulateBuilder<'mpesa> {
         C2bSimulateBuilder {
             client,
             command_id: None,
@@ -67,7 +66,7 @@ impl<'mpesa, Env: ApiEnvironment> C2bSimulateBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `CommandId` is not valid
-    pub fn command_id(mut self, command_id: CommandId) -> C2bSimulateBuilder<'mpesa, Env> {
+    pub fn command_id(mut self, command_id: CommandId) -> C2bSimulateBuilder<'mpesa> {
         self.command_id = Some(command_id);
         self
     }
@@ -76,7 +75,7 @@ impl<'mpesa, Env: ApiEnvironment> C2bSimulateBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `Amount` is not provided
-    pub fn amount<Number: Into<f64>>(mut self, amount: Number) -> C2bSimulateBuilder<'mpesa, Env> {
+    pub fn amount<Number: Into<f64>>(mut self, amount: Number) -> C2bSimulateBuilder<'mpesa> {
         self.amount = Some(amount.into());
         self
     }
@@ -86,7 +85,7 @@ impl<'mpesa, Env: ApiEnvironment> C2bSimulateBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `MSISDN` is invalid or not provided
-    pub fn msisdn(mut self, msisdn: &'mpesa str) -> C2bSimulateBuilder<'mpesa, Env> {
+    pub fn msisdn(mut self, msisdn: &'mpesa str) -> C2bSimulateBuilder<'mpesa> {
         self.msisdn = Some(msisdn);
         self
     }
@@ -95,7 +94,7 @@ impl<'mpesa, Env: ApiEnvironment> C2bSimulateBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If Till or PayBill number is invalid or not provided
-    pub fn short_code(mut self, short_code: &'mpesa str) -> C2bSimulateBuilder<'mpesa, Env> {
+    pub fn short_code(mut self, short_code: &'mpesa str) -> C2bSimulateBuilder<'mpesa> {
         self.short_code = Some(short_code);
         self
     }
@@ -107,7 +106,7 @@ impl<'mpesa, Env: ApiEnvironment> C2bSimulateBuilder<'mpesa, Env> {
     pub fn bill_ref_number(
         mut self,
         bill_ref_number: &'mpesa str,
-    ) -> C2bSimulateBuilder<'mpesa, Env> {
+    ) -> C2bSimulateBuilder<'mpesa> {
         self.bill_ref_number = Some(bill_ref_number);
         self
     }

--- a/src/services/c2b_simulate.rs
+++ b/src/services/c2b_simulate.rs
@@ -103,10 +103,7 @@ impl<'mpesa> C2bSimulateBuilder<'mpesa> {
     ///
     /// # Errors
     /// If `BillRefNumber` is invalid or not provided
-    pub fn bill_ref_number(
-        mut self,
-        bill_ref_number: &'mpesa str,
-    ) -> C2bSimulateBuilder<'mpesa> {
+    pub fn bill_ref_number(mut self, bill_ref_number: &'mpesa str) -> C2bSimulateBuilder<'mpesa> {
         self.bill_ref_number = Some(bill_ref_number);
         self
     }

--- a/src/services/dynamic_qr.rs
+++ b/src/services/dynamic_qr.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::client::Mpesa;
 use crate::constants::TransactionType;
-use crate::environment::ApiEnvironment;
 use crate::errors::{MpesaError, MpesaResult};
 
 const DYNAMIC_QR_URL: &str = "mpesa/qrcode/v1/generate";
@@ -54,9 +53,9 @@ pub struct DynamicQRResponse {
 /// Dynamic QR builder struct
 #[derive(Builder, Debug, Clone)]
 #[builder(build_fn(error = "MpesaError"))]
-pub struct DynamicQR<'mpesa, Env: ApiEnvironment> {
+pub struct DynamicQR<'mpesa> {
     #[builder(pattern = "immutable")]
-    client: &'mpesa Mpesa<Env>,
+    client: &'mpesa Mpesa,
     /// Name of the Company/M-Pesa Merchant Name
     #[builder(setter(into))]
     merchant_name: &'mpesa str,
@@ -87,8 +86,8 @@ pub struct DynamicQR<'mpesa, Env: ApiEnvironment> {
     size: &'mpesa str,
 }
 
-impl<'mpesa, Env: ApiEnvironment> From<DynamicQR<'mpesa, Env>> for DynamicQRRequest<'mpesa> {
-    fn from(express: DynamicQR<'mpesa, Env>) -> DynamicQRRequest<'mpesa> {
+impl<'mpesa> From<DynamicQR<'mpesa>> for DynamicQRRequest<'mpesa> {
+    fn from(express: DynamicQR<'mpesa>) -> DynamicQRRequest<'mpesa> {
         DynamicQRRequest {
             merchant_name: express.merchant_name,
             ref_no: express.ref_no,
@@ -100,8 +99,8 @@ impl<'mpesa, Env: ApiEnvironment> From<DynamicQR<'mpesa, Env>> for DynamicQRRequ
     }
 }
 
-impl<'mpesa, Env: ApiEnvironment> DynamicQR<'mpesa, Env> {
-    pub(crate) fn builder(client: &'mpesa Mpesa<Env>) -> DynamicQRBuilder<'mpesa, Env> {
+impl<'mpesa> DynamicQR<'mpesa> {
+    pub(crate) fn builder(client: &'mpesa Mpesa) -> DynamicQRBuilder<'mpesa> {
         DynamicQRBuilder::default().client(client)
     }
 
@@ -109,9 +108,9 @@ impl<'mpesa, Env: ApiEnvironment> DynamicQR<'mpesa, Env> {
     ///
     /// Returns a `DynamicQR` which can be used to send a request
     pub fn from_request(
-        client: &'mpesa Mpesa<Env>,
+        client: &'mpesa Mpesa,
         request: DynamicQRRequest<'mpesa>,
-    ) -> DynamicQR<'mpesa, Env> {
+    ) -> DynamicQR<'mpesa> {
         DynamicQR {
             client,
             merchant_name: request.merchant_name,

--- a/src/services/express_request.rs
+++ b/src/services/express_request.rs
@@ -141,10 +141,7 @@ impl<'mpesa> MpesaExpressRequestBuilder<'mpesa> {
     ///
     /// # Errors
     /// If `phone_number` is invalid
-    pub fn phone_number(
-        mut self,
-        phone_number: &'mpesa str,
-    ) -> MpesaExpressRequestBuilder<'mpesa> {
+    pub fn phone_number(mut self, phone_number: &'mpesa str) -> MpesaExpressRequestBuilder<'mpesa> {
         self.phone_number = Some(phone_number);
         self
     }
@@ -153,10 +150,7 @@ impl<'mpesa> MpesaExpressRequestBuilder<'mpesa> {
     ///
     /// # Errors
     /// If the `callback_url` is invalid
-    pub fn callback_url(
-        mut self,
-        callback_url: &'mpesa str,
-    ) -> MpesaExpressRequestBuilder<'mpesa> {
+    pub fn callback_url(mut self, callback_url: &'mpesa str) -> MpesaExpressRequestBuilder<'mpesa> {
         self.callback_url = Some(callback_url);
         self
     }
@@ -180,10 +174,7 @@ impl<'mpesa> MpesaExpressRequestBuilder<'mpesa> {
     }
 
     /// Optional - Used with M-Pesa PayBills.
-    pub fn account_ref(
-        mut self,
-        account_ref: &'mpesa str,
-    ) -> MpesaExpressRequestBuilder<'mpesa> {
+    pub fn account_ref(mut self, account_ref: &'mpesa str) -> MpesaExpressRequestBuilder<'mpesa> {
         self.account_ref = Some(account_ref);
         self
     }
@@ -192,10 +183,7 @@ impl<'mpesa> MpesaExpressRequestBuilder<'mpesa> {
     ///
     /// # Errors
     /// If the `CommandId` is invalid
-    pub fn transaction_type(
-        mut self,
-        command_id: CommandId,
-    ) -> MpesaExpressRequestBuilder<'mpesa> {
+    pub fn transaction_type(mut self, command_id: CommandId) -> MpesaExpressRequestBuilder<'mpesa> {
         self.transaction_type = Some(command_id);
         self
     }

--- a/src/services/express_request.rs
+++ b/src/services/express_request.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::client::Mpesa;
 use crate::constants::CommandId;
-use crate::environment::ApiEnvironment;
 use crate::errors::{MpesaError, MpesaResult};
 
 const EXPRESS_REQUEST_URL: &str = "mpesa/stkpush/v1/processrequest";
@@ -54,9 +53,9 @@ pub struct MpesaExpressRequestResponse {
     pub response_description: String,
 }
 
-pub struct MpesaExpressRequestBuilder<'mpesa, Env: ApiEnvironment> {
+pub struct MpesaExpressRequestBuilder<'mpesa> {
     business_short_code: &'mpesa str,
-    client: &'mpesa Mpesa<Env>,
+    client: &'mpesa Mpesa,
     transaction_type: Option<CommandId>,
     amount: Option<f64>,
     party_a: Option<&'mpesa str>,
@@ -68,11 +67,11 @@ pub struct MpesaExpressRequestBuilder<'mpesa, Env: ApiEnvironment> {
     pass_key: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> MpesaExpressRequestBuilder<'mpesa, Env> {
+impl<'mpesa> MpesaExpressRequestBuilder<'mpesa> {
     pub fn new(
-        client: &'mpesa Mpesa<Env>,
+        client: &'mpesa Mpesa,
         business_short_code: &'mpesa str,
-    ) -> MpesaExpressRequestBuilder<'mpesa, Env> {
+    ) -> MpesaExpressRequestBuilder<'mpesa> {
         MpesaExpressRequestBuilder {
             client,
             business_short_code,
@@ -123,7 +122,7 @@ impl<'mpesa, Env: ApiEnvironment> MpesaExpressRequestBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If thee `pass_key` is invalid
-    pub fn pass_key(mut self, pass_key: &'mpesa str) -> MpesaExpressRequestBuilder<'mpesa, Env> {
+    pub fn pass_key(mut self, pass_key: &'mpesa str) -> MpesaExpressRequestBuilder<'mpesa> {
         self.pass_key = Some(pass_key);
         self
     }
@@ -133,7 +132,7 @@ impl<'mpesa, Env: ApiEnvironment> MpesaExpressRequestBuilder<'mpesa, Env> {
     pub fn amount<Number: Into<f64>>(
         mut self,
         amount: Number,
-    ) -> MpesaExpressRequestBuilder<'mpesa, Env> {
+    ) -> MpesaExpressRequestBuilder<'mpesa> {
         self.amount = Some(amount.into());
         self
     }
@@ -145,7 +144,7 @@ impl<'mpesa, Env: ApiEnvironment> MpesaExpressRequestBuilder<'mpesa, Env> {
     pub fn phone_number(
         mut self,
         phone_number: &'mpesa str,
-    ) -> MpesaExpressRequestBuilder<'mpesa, Env> {
+    ) -> MpesaExpressRequestBuilder<'mpesa> {
         self.phone_number = Some(phone_number);
         self
     }
@@ -157,7 +156,7 @@ impl<'mpesa, Env: ApiEnvironment> MpesaExpressRequestBuilder<'mpesa, Env> {
     pub fn callback_url(
         mut self,
         callback_url: &'mpesa str,
-    ) -> MpesaExpressRequestBuilder<'mpesa, Env> {
+    ) -> MpesaExpressRequestBuilder<'mpesa> {
         self.callback_url = Some(callback_url);
         self
     }
@@ -166,7 +165,7 @@ impl<'mpesa, Env: ApiEnvironment> MpesaExpressRequestBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `party_a` is invalid
-    pub fn party_a(mut self, party_a: &'mpesa str) -> MpesaExpressRequestBuilder<'mpesa, Env> {
+    pub fn party_a(mut self, party_a: &'mpesa str) -> MpesaExpressRequestBuilder<'mpesa> {
         self.party_a = Some(party_a);
         self
     }
@@ -175,7 +174,7 @@ impl<'mpesa, Env: ApiEnvironment> MpesaExpressRequestBuilder<'mpesa, Env> {
     ///
     /// # Errors
     /// If `party_b` is invalid
-    pub fn party_b(mut self, party_b: &'mpesa str) -> MpesaExpressRequestBuilder<'mpesa, Env> {
+    pub fn party_b(mut self, party_b: &'mpesa str) -> MpesaExpressRequestBuilder<'mpesa> {
         self.party_b = Some(party_b);
         self
     }
@@ -184,7 +183,7 @@ impl<'mpesa, Env: ApiEnvironment> MpesaExpressRequestBuilder<'mpesa, Env> {
     pub fn account_ref(
         mut self,
         account_ref: &'mpesa str,
-    ) -> MpesaExpressRequestBuilder<'mpesa, Env> {
+    ) -> MpesaExpressRequestBuilder<'mpesa> {
         self.account_ref = Some(account_ref);
         self
     }
@@ -196,7 +195,7 @@ impl<'mpesa, Env: ApiEnvironment> MpesaExpressRequestBuilder<'mpesa, Env> {
     pub fn transaction_type(
         mut self,
         command_id: CommandId,
-    ) -> MpesaExpressRequestBuilder<'mpesa, Env> {
+    ) -> MpesaExpressRequestBuilder<'mpesa> {
         self.transaction_type = Some(command_id);
         self
     }
@@ -206,7 +205,7 @@ impl<'mpesa, Env: ApiEnvironment> MpesaExpressRequestBuilder<'mpesa, Env> {
     pub fn transaction_desc(
         mut self,
         description: &'mpesa str,
-    ) -> MpesaExpressRequestBuilder<'mpesa, Env> {
+    ) -> MpesaExpressRequestBuilder<'mpesa> {
         self.transaction_desc = Some(description);
         self
     }

--- a/src/services/transaction_reversal.rs
+++ b/src/services/transaction_reversal.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ApiEnvironment, CommandId, IdentifierTypes, Mpesa, MpesaError, MpesaResult};
+use crate::{CommandId, IdentifierTypes, Mpesa, MpesaError, MpesaResult};
 
 const TRANSACTION_REVERSAL_URL: &str = "mpesa/reversal/v1/request";
 
@@ -43,8 +43,8 @@ pub struct TransactionReversalResponse {
 }
 
 #[derive(Debug)]
-pub struct TransactionReversalBuilder<'mpesa, Env: ApiEnvironment> {
-    client: &'mpesa Mpesa<Env>,
+pub struct TransactionReversalBuilder<'mpesa> {
+    client: &'mpesa Mpesa,
     initiator: &'mpesa str,
     command_id: Option<CommandId>,
     transaction_id: Option<&'mpesa str>,
@@ -57,12 +57,12 @@ pub struct TransactionReversalBuilder<'mpesa, Env: ApiEnvironment> {
     amount: Option<f64>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> TransactionReversalBuilder<'mpesa, Env> {
+impl<'mpesa> TransactionReversalBuilder<'mpesa> {
     /// Creates new `TransactionReversalBuilder`
     pub fn new(
-        client: &'mpesa Mpesa<Env>,
+        client: &'mpesa Mpesa,
         initiator: &'mpesa str,
-    ) -> TransactionReversalBuilder<'mpesa, Env> {
+    ) -> TransactionReversalBuilder<'mpesa> {
         TransactionReversalBuilder {
             client,
             initiator,

--- a/src/services/transaction_status.rs
+++ b/src/services/transaction_status.rs
@@ -56,10 +56,7 @@ pub struct TransactionStatusBuilder<'mpesa> {
 
 impl<'mpesa> TransactionStatusBuilder<'mpesa> {
     /// Creates new `TransactionStatusBuilder`
-    pub fn new(
-        client: &'mpesa Mpesa,
-        initiator: &'mpesa str,
-    ) -> TransactionStatusBuilder<'mpesa> {
+    pub fn new(client: &'mpesa Mpesa, initiator: &'mpesa str) -> TransactionStatusBuilder<'mpesa> {
         TransactionStatusBuilder {
             client,
             initiator,

--- a/src/services/transaction_status.rs
+++ b/src/services/transaction_status.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ApiEnvironment, CommandId, IdentifierTypes, Mpesa, MpesaError, MpesaResult};
+use crate::{CommandId, IdentifierTypes, Mpesa, MpesaError, MpesaResult};
 
 const TRANSACTION_STATUS_URL: &str = "mpesa/transactionstatus/v1/query";
 
@@ -41,8 +41,8 @@ pub struct TransactionStatusResponse {
 }
 
 #[derive(Debug)]
-pub struct TransactionStatusBuilder<'mpesa, Env: ApiEnvironment> {
-    client: &'mpesa Mpesa<Env>,
+pub struct TransactionStatusBuilder<'mpesa> {
+    client: &'mpesa Mpesa,
     initiator: &'mpesa str,
     command_id: Option<CommandId>,
     transaction_id: Option<&'mpesa str>,
@@ -54,12 +54,12 @@ pub struct TransactionStatusBuilder<'mpesa, Env: ApiEnvironment> {
     occasion: Option<&'mpesa str>,
 }
 
-impl<'mpesa, Env: ApiEnvironment> TransactionStatusBuilder<'mpesa, Env> {
+impl<'mpesa> TransactionStatusBuilder<'mpesa> {
     /// Creates new `TransactionStatusBuilder`
     pub fn new(
-        client: &'mpesa Mpesa<Env>,
+        client: &'mpesa Mpesa,
         initiator: &'mpesa str,
-    ) -> TransactionStatusBuilder<'mpesa, Env> {
+    ) -> TransactionStatusBuilder<'mpesa> {
         TransactionStatusBuilder {
             client,
             initiator,


### PR DESCRIPTION
Prior to this change, all the Request builders had to have the ApiEnvironment generic parameter  which felt a bit off. (RequestBuilders shouldn't concern themselves with the APIEnvironment)

 I've refactored the MpesaClient abit, instead of holding the Trait, to just holds the values it gets from the`ApiEnvironment` trait implementors. 

The result should ideally be, less noise, which makes the code a bit easier to read.

Closes #94 

