### PR TITLE
Fix Doc Tests Compilation

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
+          profile: default
           toolchain: stable
           override: true
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
Basically replaced: 
```
env!("CLIENT_KEY")
env!("CLIENT_SECRET") 
```
with
```rust
std::env::var("CLIENT_KEY").unwrap(),
std::env::var("CLIENT_SECRET").unwrap(),
```
since the env variables aren't available at compile time we can't use env! directly.

Fixes #97 